### PR TITLE
fix js that causes grunt to abort due to warnings

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,5 +11,6 @@
   "eqnull": true,
   "laxcomma": false,
   "node": true,
-  "strict": false
+  "strict": false,
+   "es5": true
 }

--- a/tasks/assets_versioning.js
+++ b/tasks/assets_versioning.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
     }
 
     if (options.post && options.skipExisting) {
-      grunt.fail.fatal("To work, the option skipExisting needs the post option to be false. Please update your configuration to have either post or skipExisting set to false.")
+      grunt.fail.fatal("To work, the option skipExisting needs the post option to be false. Please update your configuration to have either post or skipExisting set to false.");
     }
 
     /**

--- a/tasks/versioners/versionerFactory.js
+++ b/tasks/versioners/versionerFactory.js
@@ -23,7 +23,7 @@ module.exports = function (options, taskData) {
     Versioner = ExternalVersioner;
   } else {
     grunt.log.debug('Internal Task Mode');
-    if (options.tasks) grunt.log.warn("'tasks' option ignored: it can only be an array!");
+    if (options.tasks) { grunt.log.warn("'tasks' option ignored: it can only be an array!"); }
     Versioner = InternalVersioner;
   }
 


### PR DESCRIPTION
grunt aborts due to missing semicolon. add semicolon. 

grunt aborts due to expected "{". Add missing "{", "}" for if statement.