### PR TITLE
Address lodash security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "lodash": "^2.4.1",
+    "lodash": ">=4.17.19",
     "moment": "^2.9.0",
     "slash": "^1.0.0"
   }

--- a/tasks/assets_versioning.js
+++ b/tasks/assets_versioning.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
       runTask: true
     });
 
-    if (!_.contains(['hash', 'date'], options.tag)) {
+    if (!_.includes(['hash', 'date'], options.tag)) {
       grunt.fail.warn('Invalid argument : options.tag should be equal to date or hash', 1);
     }
 

--- a/tasks/versioners/abstractVersioner.js
+++ b/tasks/versioners/abstractVersioner.js
@@ -188,7 +188,7 @@ AbstractVersioner.prototype.createPreVersioningSurrogateTask = function (task) {
     // push to the map of versions
 
     var versionedPath = destFilePath.replace(this.options.versionsMapTrimPath, '');
-    if (_.contains(allVersionedPath, versionedPath)) {
+    if (_.includes(allVersionedPath, versionedPath)) {
       grunt.fail.warn("Duplicate versioned path detected: '" + versionedPath +"'.");
     } else {
       allVersionedPath.push(versionedPath);


### PR DESCRIPTION
I can see a number of forks that have attempted to simply update the version dependence, and the same strategy is also applied in the existing PR #82

Simply updating the dependency version appears to lead to errors (at least in my usage) due to a breaking change between lodash 3.x and 4.x, so this PR adds a further update to change usages of `_.contains` to `_.includes` to restore working behaviour with lodash >=4.17.19 (older versions have at least one security vulnerability).

I've also taken the opportunity to change the version requirement to a ">=", since this package doesn't get many updates and this will allow users of this package to update lodash to address future security vulnerabilities more easily (even if they *may* run into incompatibilities due to breaking changes). It would appear that lodash 3.x had no breaking changes that affected this package, so the version requirement has been needlessly strict.